### PR TITLE
Spatial Queries

### DIFF
--- a/solr/solr.xml
+++ b/solr/solr.xml
@@ -9,7 +9,7 @@
  	All paths are relative to the Solr Home directory 
  -->
 <solr persistent="true">
-	<cores defaultCoreName="swiftriver" host="${host:}" hostPort="${jetty.port:}">
+	<cores adminPath="/admin/cores" defaultCoreName="swiftriver" host="${host:}" hostPort="${jetty.port:}">
 		<core name="swiftriver" instanceDir="swiftriver" dataDir="data" loadOnStartup="true"/>
 	</cores>
 </solr>

--- a/solr/solr.xml
+++ b/solr/solr.xml
@@ -8,8 +8,8 @@
  <!--
  	All paths are relative to the Solr Home directory 
  -->
-<solr persistent="false">
+<solr persistent="true">
 	<cores defaultCoreName="swiftriver" host="${host:}" hostPort="${jetty.port:}">
-		<core name="swiftriver" instanceDir="swiftriver"/>
+		<core name="swiftriver" instanceDir="swiftriver" dataDir="data" loadOnStartup="true"/>
 	</cores>
 </solr>

--- a/solr/swiftriver/conf/schema.xml
+++ b/solr/swiftriver/conf/schema.xml
@@ -116,6 +116,7 @@
     <field name="title" type="text_general" indexed="true" stored="true" termVectors="true"/>
     <field name="content" type="text_general" indexed="true" stored="true" termVectors="true"/>
     <field name="datePublished" type="date" indexed="true" stored="true"/>
+    <field name="geo" type="location_rpt" indexed="true" stored="true" multiValued="true"/>
     <field name="riverId" type="long" indexed="true" stored="false" multiValued="true"/>
     <field name="bucketId" type="long" indexed="true" stored="false" multiValued="true"/>
     <field name="signature" type="text_general" stored="true" indexed="true"/>

--- a/solr/swiftriver/conf/solrconfig.xml
+++ b/solr/swiftriver/conf/solrconfig.xml
@@ -27,8 +27,6 @@
         solr.RAMDirectoryFactory is memory based, not persistent, and doesn't work with replication. -->
 	<directoryFactory name="DirectoryFactory" class="${solr.directoryFactory:solr.StandardDirectoryFactory}"/>
 
-	<dataDir>solr/swiftriver/data</dataDir>
-  
 	<!--
   	These settings control low-level behaviour of indexing
     -->

--- a/src/main/java/com/ushahidi/swiftriver/core/api/auth/crowdmapid/CrowdmapIDClient.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/auth/crowdmapid/CrowdmapIDClient.java
@@ -188,7 +188,7 @@ public class CrowdmapIDClient {
 	 * @return
 	 */
 	public boolean isRegistered(String email) {
-		logger.info("Checking if {} is registered", email);
+		logger.debug("Checking if {} is registered", email);
 		List<NameValuePair> params = new ArrayList<NameValuePair>();
 		params.add(new BasicNameValuePair("email", email));
 		
@@ -286,8 +286,6 @@ public class CrowdmapIDClient {
 				logger.error("The server returned status {} - {}", statusCode,  apiResponse);
 				return responseMap;
 			}
-
-			logger.debug("{} returned response: {}", this.serverURL, apiResponse);
 			
 		} catch (ClientProtocolException e) {
 			logger.error("An error occurred when processing request: {} - {}",

--- a/src/main/java/com/ushahidi/swiftriver/core/api/controller/BucketsController.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/controller/BucketsController.java
@@ -307,6 +307,7 @@ public class BucketsController extends AbstractController {
 			@RequestParam(value = "channels", required = false) String channels,
 			@RequestParam(value = "photos", required = false) Boolean photos,
 			@RequestParam(value = "state", required = false) String state,
+			@RequestParam(value = "locations", required = false) String locations,
 			Principal principal) {
 
 		if (maxId == null) {
@@ -373,6 +374,7 @@ public class BucketsController extends AbstractController {
 		dropFilter.setRead(isRead);
 		dropFilter.setPhotos(photos);
 		dropFilter.setKeywords(keywords);
+		dropFilter.setBoundingBox(locations);
 
 		// Check for errors
 		if (!errors.isEmpty()) {

--- a/src/main/java/com/ushahidi/swiftriver/core/api/controller/RiversController.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/controller/RiversController.java
@@ -361,7 +361,8 @@ public class RiversController extends AbstractController {
 			@RequestParam(value = "channels", required = false) String channels,
 			@RequestParam(value = "channel_ids", required = false) String cIds,
 			@RequestParam(value = "state", required = false) String state,
-			@RequestParam(value = "photos", required = false) Boolean photos)
+			@RequestParam(value = "photos", required = false) Boolean photos,
+			@RequestParam(value = "locations", required = false) String locations)
 			throws NotFoundException {
 
 		if (maxId == null) {
@@ -443,6 +444,7 @@ public class RiversController extends AbstractController {
 		dropFilter.setRead(isRead);
 		dropFilter.setPhotos(photos);
 		dropFilter.setKeywords(keywords);
+		dropFilter.setBoundingBox(locations);
 
 		// Check for errors
 		if (!errors.isEmpty()) {

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dao/DropDao.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dao/DropDao.java
@@ -49,18 +49,4 @@ public interface DropDao extends GenericDao<Drop> {
 	 */
 	public List<Drop> findAll(long sinceId, int batchSize);
 
-	/**
-	 * Sets the <code>riverIds</code> property for each {@link Drop}
-	 * in <code>drops</code>
-	 * 
-	 * @param drops
-	 */
-	public void populateRiverIds(List<Drop> drops);
-
-	/**
-	 * Sets the <code>bucketIds</code> property for each {@link Drop}
-	 * in <code>drops</code>
-	 * @param drops
-	 */
-	public void populateBucketIds(List<Drop> drops);
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dao/impl/JpaDropDao.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dao/impl/JpaDropDao.java
@@ -754,78 +754,11 @@ public class JpaDropDao extends AbstractJpaDao<Drop> implements DropDao {
 	 * @see com.ushahidi.swiftriver.core.api.dao.DropDao#findAll(long, int)
 	 */
 	public List<Drop> findAll(long sinceId, int batchSize) {
-		TypedQuery<Drop> query = em.createQuery("FROM Drop d WHERE d.id > :sinceId ORDER BY d.id ASC", 
-				Drop.class);
+		String qlString = "FROM Drop d WHERE d.id > :sinceId ORDER BY d.id ASC";
+		TypedQuery<Drop> query = em.createQuery(qlString, Drop.class);
 		query.setParameter("sinceId", sinceId);
 		query.setMaxResults(batchSize);
 
 		return query.getResultList();
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see com.ushahidi.swiftriver.core.api.dao.DropDao#populateRiverIds(java.util.List)
-	 */
-	public void populateRiverIds(List<Drop> drops) {
-		// Store the drop index
-		Map<Long, Integer> dropIndex = new HashMap<Long, Integer>();
-		List<Long> dropIds = new ArrayList<Long>();
-		int index = 0;
-		for (Drop drop: drops) {
-			dropIds.add(drop.getId());
-			dropIndex.put(drop.getId(), index);
-			index++;
-		}
-
-		String sql = "SELECT `droplet_id`, `river_id` " +
-				"FROM `rivers_droplets` WHERE `droplet_id` IN (:dropIds)";
-		
-		MapSqlParameterSource paramMap = new MapSqlParameterSource();
-		paramMap.addValue("dropIds", dropIds);
-
-		for(Map<String, Object> row: namedJdbcTemplate.queryForList(sql, paramMap)) {
-			Long dropId = ((Number) row.get("droplet_id")).longValue();
-			Long riverId = ((Number) row.get("river_id")).longValue();
-			
-			Drop drop = drops.get(dropIndex.get(dropId));
-			if (drop.getRiverIds() == null) {
-				drop.setRiverIds(new ArrayList<Long>());
-			}
-			drop.getRiverIds().add(riverId);
-		}
-		
-	}
-
-	/*
-	 * (non-Javadoc)
-	 * @see com.ushahidi.swiftriver.core.api.dao.DropDao#populateBucketIds(java.util.List)
-	 */
-	public void populateBucketIds(List<Drop> drops) {
-		// Store the drop index
-		Map<Long, Integer> dropIndex = new HashMap<Long, Integer>();
-		List<Long> dropIds = new ArrayList<Long>();
-		int index = 0;
-		for (Drop drop: drops) {
-			dropIds.add(drop.getId());
-			dropIndex.put(drop.getId(), index);
-			index++;
-		}
-		
-		String sql = "SELECT `droplet_id`, `bucket_id` " +
-				"FROM `buckets_droplets` WHERE `droplet_id` IN (:dropIds)";
-
-		MapSqlParameterSource paramMap = new MapSqlParameterSource();
-		paramMap.addValue("dropIds", dropIds);
-
-		for(Map<String, Object> row: namedJdbcTemplate.queryForList(sql, paramMap)) {
-			Long dropId = ((Number) row.get("droplet_id")).longValue();
-			Long bucketId = ((Number) row.get("bucket_id")).longValue();
-			
-			Drop drop = drops.get(dropIndex.get(dropId));
-			if (drop.getBucketIds() == null) {
-				drop.setBucketIds(new ArrayList<Long>());
-			}
-			drop.getBucketIds().add(bucketId);
-		}
 	}
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/filter/DropFilter.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/filter/DropFilter.java
@@ -22,6 +22,13 @@ import java.util.List;
 
 import com.ushahidi.swiftriver.core.api.exception.InvalidFilterException;
 
+/**
+ * This is a wrapper class for the parameters used
+ * for querying drops  
+ * 
+ * @author ekala
+ *
+ */
 public class DropFilter {
 
 	private List<String> channels;
@@ -43,6 +50,8 @@ public class DropFilter {
 	private List<Long> dropIds;
 
 	private String keywords;
+
+	private BoundingBox boundingBox;
 
 	/**
 	 * @return the channels
@@ -190,6 +199,79 @@ public class DropFilter {
 		this.keywords = keywords;
 	}
 	
+	public BoundingBox getBoundingBox() {
+		return boundingBox;
+	}
+
+	/**
+	 * Creates a {@link BoundingBox} from the latitude,longitude
+	 * pairs specified in the <code>locations</code> parameter
+	 * 
+	 * @param boundingBoxStr
+	 * @throws InvalidFilterException
+	 */
+	public void setBoundingBox(String boundingBoxStr) throws InvalidFilterException {
+		if (boundingBoxStr == null)
+			return;
+
+		// Validate the location bounds
+		String[] bounds = boundingBoxStr.split(",");
+		if (bounds.length != 4) {
+			throw new InvalidFilterException(String.format(
+					"Invalid bounding box '[%s]'", boundingBoxStr));
+		}
+		
+		// Get the bounding box values
+		float latFrom = Float.parseFloat(bounds[0]);
+		float lonFrom = Float.parseFloat(bounds[1]);
+		float latTo = Float.parseFloat(bounds[2]);
+		float lonTo = Float.parseFloat(bounds[3]);
+		
+		// Validate each value
+		if (!isValidLatitude(latFrom)) {
+			throw new InvalidFilterException(String.format(
+					"Invalid latitude in bounding box: %f", latFrom));
+		}
+
+		if (!isValidLongitude(lonFrom)) {
+			throw new InvalidFilterException(String.format(
+					"Invalid longitude in bounding box %f", lonFrom));
+		}
+		
+		if (!isValidLatitude(latTo)) {
+			throw new InvalidFilterException(String.format(
+					"Invalid latitude in bounding box: %f", latTo));
+		}
+		
+		if (!isValidLongitude(lonTo)) {
+			throw new InvalidFilterException(String.format(
+					"Invalid longitude in bounding box %f", lonTo));
+		}
+
+		// Create and set the bounding box
+		this.boundingBox = new BoundingBox(latFrom, lonFrom, latTo, lonTo);
+	}
+
+	/**
+	 * Validates the specified <code>latitude</code> value
+	 * 
+	 * @param latitude
+	 * @return
+	 */
+	private boolean isValidLatitude(float latitude) {
+		return latitude <= 90 && latitude >= -90;
+	}
+
+	/**
+	 * Validates the specified <code>longitude</code> value
+	 * 
+	 * @param longitude
+	 * @return
+	 */
+	private boolean isValidLongitude(float longitude) {
+		return longitude <= 180 && longitude >= -180;
+	}
+
 	/**
 	 * Checks if dateFrom = dateTo. If they are equal,
 	 * dateTo = dateFrom + 24 hrs
@@ -199,9 +281,74 @@ public class DropFilter {
 			Calendar calendar = Calendar.getInstance();
 			calendar.setTime(dateTo);
 			calendar.add(Calendar.HOUR, 24);
-
+	
 			this.dateTo = calendar.getTime(); 
 		}
 	}
 
+	/**
+	 * Helper class for representing a bounding box
+	 * for use in spatial queries
+	 * 
+	 * @author ekala
+	 */
+	public static class BoundingBox {
+		
+		private Float latFrom;
+
+		private Float lonFrom;
+
+		private Float latTo;
+
+		private Float lonTo;
+
+		/**
+		 * Initializes the bounding box
+		 * 
+		 * @param latFrom
+		 * @param lonFrom
+		 * @param latTo
+		 * @param lonTo
+		 */
+		public BoundingBox(Float latFrom, Float lonFrom, Float latTo, Float lonTo) {
+			setLatFrom(latFrom);
+			setLonFrom(lonFrom);
+			setLatTo(latTo);
+			setLonTo(lonTo);
+		}
+
+		public Float getLatFrom() {
+			return latFrom;
+		}
+
+		public void setLatFrom(Float latFrom) {
+			this.latFrom = latFrom;
+		}
+
+		public Float getLonFrom() {
+			return lonFrom;
+		}
+
+		public void setLonFrom(Float lonFrom) {
+			this.lonFrom = lonFrom;
+		}
+
+		public Float getLatTo() {
+			return latTo;
+		}
+
+		public void setLatTo(Float latTo) {
+			this.latTo = latTo;
+		}
+
+		public Float getLonTo() {
+			return lonTo;
+		}
+
+		public void setLonTo(Float lonTo) {
+			this.lonTo = lonTo;
+		}
+		
+		
+	}
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/filter/DropFilter.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/filter/DropFilter.java
@@ -205,7 +205,10 @@ public class DropFilter {
 
 	/**
 	 * Creates a {@link BoundingBox} from the latitude,longitude
-	 * pairs specified in the <code>locations</code> parameter
+	 * pairs specified in the <code>locations</code> parameter.
+	 * 
+	 * The SouthWest corner of the bounding box should always
+	 * come first
 	 * 
 	 * @param boundingBoxStr
 	 * @throws InvalidFilterException
@@ -223,9 +226,9 @@ public class DropFilter {
 		
 		// Get the bounding box values
 		float latFrom = Float.parseFloat(bounds[0]);
-		float lonFrom = Float.parseFloat(bounds[1]);
+		float lngFrom = Float.parseFloat(bounds[1]);
 		float latTo = Float.parseFloat(bounds[2]);
-		float lonTo = Float.parseFloat(bounds[3]);
+		float lngTo = Float.parseFloat(bounds[3]);
 		
 		// Validate each value
 		if (!isValidLatitude(latFrom)) {
@@ -233,9 +236,9 @@ public class DropFilter {
 					"Invalid latitude in bounding box: %f", latFrom));
 		}
 
-		if (!isValidLongitude(lonFrom)) {
+		if (!isValidLongitude(lngFrom)) {
 			throw new InvalidFilterException(String.format(
-					"Invalid longitude in bounding box %f", lonFrom));
+					"Invalid longitude in bounding box %f", lngFrom));
 		}
 		
 		if (!isValidLatitude(latTo)) {
@@ -243,13 +246,21 @@ public class DropFilter {
 					"Invalid latitude in bounding box: %f", latTo));
 		}
 		
-		if (!isValidLongitude(lonTo)) {
+		if (!isValidLongitude(lngTo)) {
 			throw new InvalidFilterException(String.format(
-					"Invalid longitude in bounding box %f", lonTo));
+					"Invalid longitude in bounding box %f", lngTo));
 		}
-
+		
+		// Verify that the SouthWest corner is the first pair
+		// in the bounding box
+		if ((latFrom > latTo) || (lngFrom > lngTo) ) {
+			throw new InvalidFilterException(String.format(
+					"Invalid bounding box: '%s'. The SouthWest corner should be specified first",
+					boundingBoxStr));
+		}
+		
 		// Create and set the bounding box
-		this.boundingBox = new BoundingBox(latFrom, lonFrom, latTo, lonTo);
+		this.boundingBox = new BoundingBox(latFrom, lngFrom, latTo, lngTo);
 	}
 
 	/**
@@ -287,8 +298,9 @@ public class DropFilter {
 	}
 
 	/**
-	 * Helper class for representing a bounding box
-	 * for use in spatial queries
+	 * This is a class for representing a rectangular geographical area
+	 * (bounding box) to be used in performing spatial queries via
+	 * Solr
 	 * 
 	 * @author ekala
 	 */
@@ -296,57 +308,96 @@ public class DropFilter {
 		
 		private Float latFrom;
 
-		private Float lonFrom;
+		private Float lngFrom;
 
 		private Float latTo;
 
-		private Float lonTo;
+		private Float lngTo;
 
 		/**
 		 * Initializes the bounding box
 		 * 
 		 * @param latFrom
-		 * @param lonFrom
+		 * @param lngFrom
 		 * @param latTo
-		 * @param lonTo
+		 * @param lngTo
 		 */
-		public BoundingBox(Float latFrom, Float lonFrom, Float latTo, Float lonTo) {
+		public BoundingBox(Float latFrom, Float lngFrom, Float latTo, Float lngTo) {
 			setLatFrom(latFrom);
-			setLonFrom(lonFrom);
+			setLngFrom(lngFrom);
 			setLatTo(latTo);
-			setLonTo(lonTo);
+			setLngTo(lngTo);
 		}
 
+		/**
+		 * Returns the latitude for the SouthWest corner of the bounding box
+		 * 
+		 * @return
+		 */
 		public Float getLatFrom() {
 			return latFrom;
 		}
 
+		/**
+		 * Sets the latitude of the SouthWest corner of the bounding box
+		 * @param latFrom
+		 */
 		public void setLatFrom(Float latFrom) {
 			this.latFrom = latFrom;
 		}
 
-		public Float getLonFrom() {
-			return lonFrom;
+		/**
+		 * Returns the longitude of the SouthWest corner of the bounding box
+		 * 
+		 * @return
+		 */
+		public Float getLngFrom() {
+			return lngFrom;
 		}
 
-		public void setLonFrom(Float lonFrom) {
-			this.lonFrom = lonFrom;
+		/**
+		 * Sets the longitude for the SouthWest corner of the bounding box
+		 * 
+		 * @param lngFrom
+		 */
+		public void setLngFrom(Float lngFrom) {
+			this.lngFrom = lngFrom;
 		}
 
+		/**
+		 * Returns the latitude of the NorthEast corner of the bounding box
+		 * 
+		 * @return
+		 */
 		public Float getLatTo() {
 			return latTo;
 		}
 
+		/**
+		 * Sets the latitude for the NorthEast corner of the bounding box
+		 * 
+		 * @param latTo
+		 */
 		public void setLatTo(Float latTo) {
 			this.latTo = latTo;
 		}
 
-		public Float getLonTo() {
-			return lonTo;
+		/**
+		 * Gets the longitude of the NorthEast corner of the bounding box
+		 * 
+		 * @return
+		 */
+		public Float getLngTo() {
+			return lngTo;
 		}
 
-		public void setLonTo(Float lonTo) {
-			this.lonTo = lonTo;
+		/**
+		 * Sets the longigude of the NorthEast corner of the bounding box
+		 * 
+		 * @param lngTo
+		 */
+		public void setLngTo(Float lngTo) {
+			this.lngTo = lngTo;
 		}
 		
 		

--- a/src/main/java/com/ushahidi/swiftriver/core/api/service/BucketService.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/service/BucketService.java
@@ -75,7 +75,6 @@ import com.ushahidi.swiftriver.core.model.Place;
 import com.ushahidi.swiftriver.core.model.Tag;
 import com.ushahidi.swiftriver.core.solr.DropDocument;
 import com.ushahidi.swiftriver.core.solr.repository.DropDocumentRepository;
-import com.ushahidi.swiftriver.core.solr.util.QueryUtil;
 import com.ushahidi.swiftriver.core.util.MD5Util;
 
 /**
@@ -631,19 +630,15 @@ public class BucketService {
 		
 		List<GetDropDTO> getDropDTOs = new ArrayList<GetDropDTO>();
 
-		if (dropFilter.getKeywords() != null) {
-			String searchTerm = QueryUtil.getQueryString(dropFilter.getKeywords());
+		if (dropFilter.getKeywords() != null || dropFilter.getBoundingBox() != null) {
 
 			PageRequest pageRequest = new PageRequest(page - 1, dropCount);
 			List<DropDocument> dropDocuments = repository.findInBucket(id, 
-					searchTerm, pageRequest);
+					dropFilter, pageRequest);
 			
 			if (dropDocuments.isEmpty()) {
 				return getDropDTOs;
 			}
-			// Logger
-			logger.info("Found {} matches for '{}' in bucket" + id, 
-					dropDocuments.size(), searchTerm);
 
 			List<Long> dropIds = new ArrayList<Long>();
 			for (DropDocument document: dropDocuments) {

--- a/src/main/java/com/ushahidi/swiftriver/core/api/service/RiverService.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/service/RiverService.java
@@ -93,7 +93,6 @@ import com.ushahidi.swiftriver.core.model.Rule;
 import com.ushahidi.swiftriver.core.model.Tag;
 import com.ushahidi.swiftriver.core.solr.DropDocument;
 import com.ushahidi.swiftriver.core.solr.repository.DropDocumentRepository;
-import com.ushahidi.swiftriver.core.solr.util.QueryUtil;
 import com.ushahidi.swiftriver.core.util.ErrorUtil;
 import com.ushahidi.swiftriver.core.util.MD5Util;
 
@@ -422,13 +421,12 @@ public class RiverService {
 
 		List<GetDropDTO> getDropDTOs = new ArrayList<GetDropDTO>();
 
-		// If keywords have been specified, perform search on Solr
-		if (dropFilter.getKeywords() != null) {
-			String searchTerm = QueryUtil.getQueryString(dropFilter.getKeywords());
+		// Farm fulltext and geospatial search to Solr
+		if (dropFilter.getKeywords() != null || dropFilter.getBoundingBox() != null) {
 
 			PageRequest pageRequest = new PageRequest(page - 1, dropCount);
 			List<DropDocument> dropDocuments = repository.findInRiver(id, 
-					searchTerm, pageRequest);
+					dropFilter, pageRequest);
 
 			if (dropDocuments.isEmpty()) {
 				return getDropDTOs;

--- a/src/main/java/com/ushahidi/swiftriver/core/scheduling/DropIndexingTask.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/scheduling/DropIndexingTask.java
@@ -26,6 +26,7 @@ import java.util.Properties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ushahidi.swiftriver.core.api.dao.DropDao;
 import com.ushahidi.swiftriver.core.api.service.DropIndexService;
@@ -90,6 +91,7 @@ public class DropIndexingTask {
 	 * 
 	 * @throws IOException
 	 */
+	@Transactional
 	public void updateDropIndex() throws IOException {
 		int batchSize = Integer.parseInt(indexerProperties.getProperty(batchSizePropertyKey));
 		long lastDropId = Long.parseLong(indexerProperties.getProperty(lastDropIdPropertyKey));
@@ -101,11 +103,6 @@ public class DropIndexingTask {
 			return;
 		}
 		
-		// Set the riverId and bucketId properties
-		logger.info("Setting the riverId and bucketId properties");
-		dropDao.populateRiverIds(drops);
-		dropDao.populateBucketIds(drops);
-
 		// Add drops to search index
 		dropIndexService.addAllToIndex(drops);
 

--- a/src/main/java/com/ushahidi/swiftriver/core/solr/DropDocument.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/solr/DropDocument.java
@@ -51,6 +51,9 @@ public class DropDocument {
 	@Field("bucketId")
 	private List<Long> bucketIds;
 	
+	@Field
+	private List<String> geo;
+	
 	public String getId() {
 		return id;
 	}
@@ -105,6 +108,14 @@ public class DropDocument {
 
 	public void setBucketIds(List<Long> bucketIds) {
 		this.bucketIds = bucketIds;
+	}
+
+	public List<String> getGeo() {
+		return geo;
+	}
+
+	public void setGeo(List<String> geo) {
+		this.geo = geo;
 	}
 
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/solr/repository/DropDocumentRepositoryImpl.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/solr/repository/DropDocumentRepositoryImpl.java
@@ -122,8 +122,8 @@ public class DropDocumentRepositoryImpl implements DropSearchRepository {
 	 */
 	private String getBoundingBoxFilterQuery(BoundingBox boundingBox) {
 		return String.format("geo:[%s,%s TO %s,%s]", 
-				boundingBox.getLatFrom(), boundingBox.getLonFrom(), 
-				boundingBox.getLatTo(), boundingBox.getLonTo());
+				boundingBox.getLatFrom(), boundingBox.getLngFrom(), 
+				boundingBox.getLatTo(), boundingBox.getLngTo());
 	}
 
 	private List<DropDocument> getSearchResults(SolrQuery solrQuery) {

--- a/src/main/java/com/ushahidi/swiftriver/core/solr/repository/DropDocumentRepositoryImpl.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/solr/repository/DropDocumentRepositoryImpl.java
@@ -28,7 +28,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.solr.core.SolrTemplate;
 
+import com.ushahidi.swiftriver.core.api.filter.DropFilter;
+import com.ushahidi.swiftriver.core.api.filter.DropFilter.BoundingBox;
 import com.ushahidi.swiftriver.core.solr.DropDocument;
+import com.ushahidi.swiftriver.core.solr.util.QueryUtil;
 
 public class DropDocumentRepositoryImpl implements DropSearchRepository {
 
@@ -49,8 +52,8 @@ public class DropDocumentRepositoryImpl implements DropSearchRepository {
 	 * (java.lang.String, org.springframework.data.domain.Pageable)
 	 */
 	public List<DropDocument> find(String searchTerm, Pageable pageable) {
-
-		SolrQuery solrQuery = getPreparedSolrQuery(searchTerm, pageable);
+		SolrQuery solrQuery = getPreparedSolrQuery(QueryUtil.getQueryString(searchTerm),
+				pageable);
 		return getSearchResults(solrQuery);
 	}
 	
@@ -62,10 +65,22 @@ public class DropDocumentRepositoryImpl implements DropSearchRepository {
 	 * (java.lang.Long, java.lang.String,
 	 * org.springframework.data.domain.Pageable)
 	 */
-	public List<DropDocument> findInRiver(Long riverId, String searchTerm,
+	public List<DropDocument> findInRiver(Long riverId, DropFilter dropFilter,
 			Pageable pageable) {
-		searchTerm = String.format(searchTerm + " AND riverId:(%d)", riverId);
+		String searchTerm = QueryUtil.getQueryString(dropFilter.getKeywords());
 		SolrQuery solrQuery = getPreparedSolrQuery(searchTerm, pageable);
+		
+		// Add the filter query
+		String riverFilter = String.format("riverId:(%d)", riverId);
+		
+		// Do we have a bounding box filter?
+		if (dropFilter.getBoundingBox() == null) {
+			solrQuery.addFilterQuery(riverFilter);
+		} else {
+			String boundingBoxFilter = getBoundingBoxFilterQuery(
+					dropFilter.getBoundingBox());
+			solrQuery.addFilterQuery(riverFilter, boundingBoxFilter);
+		}
 		
 		return getSearchResults(solrQuery);
 	}
@@ -77,12 +92,38 @@ public class DropDocumentRepositoryImpl implements DropSearchRepository {
 	 * findInBucket(java.lang.Long, java.lang.String,
 	 * org.springframework.data.domain.Pageable)
 	 */
-	public List<DropDocument> findInBucket(Long bucketId, String searchTerm,
+	public List<DropDocument> findInBucket(Long bucketId, DropFilter dropFilter,
 			Pageable pageable) {
-		searchTerm = String.format(searchTerm + " AND bucketId:(%d)", bucketId);
+		String searchTerm = QueryUtil.getQueryString(dropFilter.getKeywords());
 		SolrQuery solrQuery = getPreparedSolrQuery(searchTerm, pageable);
+
+		// Add the filter query
+		String bucketFilter = String.format("bucketId:(%d)", bucketId);
+		
+		// Do we have a bounding box filter?
+		if (dropFilter.getBoundingBox() == null) {
+			solrQuery.addFilterQuery(bucketFilter);
+		} else {
+			String boundingBoxFilter = getBoundingBoxFilterQuery(
+					dropFilter.getBoundingBox());
+
+			solrQuery.addFilterQuery(bucketFilter, boundingBoxFilter);
+		}
 		
 		return getSearchResults(solrQuery);
+	}
+
+	/**
+	 * Builds and returns a Solr bounding filter query using
+	 * Solr's range query syntax
+	 *   
+	 * @param boundingBox
+	 * @return
+	 */
+	private String getBoundingBoxFilterQuery(BoundingBox boundingBox) {
+		return String.format("geo:[%s,%s TO %s,%s]", 
+				boundingBox.getLatFrom(), boundingBox.getLonFrom(), 
+				boundingBox.getLatTo(), boundingBox.getLonTo());
 	}
 
 	private List<DropDocument> getSearchResults(SolrQuery solrQuery) {
@@ -102,7 +143,6 @@ public class DropDocumentRepositoryImpl implements DropSearchRepository {
 		Integer start = pageable.getPageNumber() * pageable.getPageSize();
 
 		SolrQuery solrQuery = new SolrQuery();
-		
 		solrQuery.set("q", searchTerm);
 		solrQuery.set("defType", "edismax");
 		solrQuery.set("stopwords", true);
@@ -112,4 +152,5 @@ public class DropDocumentRepositoryImpl implements DropSearchRepository {
 
 		return solrQuery;
 	}
+	
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/solr/repository/DropSearchRepository.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/solr/repository/DropSearchRepository.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 
+import com.ushahidi.swiftriver.core.api.filter.DropFilter;
 import com.ushahidi.swiftriver.core.model.Bucket;
 import com.ushahidi.swiftriver.core.model.River;
 import com.ushahidi.swiftriver.core.solr.DropDocument;
@@ -46,11 +47,12 @@ public interface DropSearchRepository {
 	 * in their title or content
 	 * 
 	 * @param riverId
-	 * @param searchTerm
+	 * @param dropFilter
 	 * @param pageable
 	 * @return
 	 */
-	public List<DropDocument> findInRiver(Long riverId, String searchTerm, Pageable pageable);
+	public List<DropDocument> findInRiver(Long riverId, DropFilter dropFilter, 
+			Pageable pageable);
 
 	/**
 	 * Returns all {@link DropDocument} entities in the {@link Bucket} with the
@@ -58,10 +60,11 @@ public interface DropSearchRepository {
 	 * in their title or content
 	 * 
 	 * @param bucketId
-	 * @param searchTerm
+	 * @param dropFilter
 	 * @param pageable
 	 * @return
 	 */
-	public List<DropDocument> findInBucket(Long bucketId, String searchTerm, Pageable pageable);
+	public List<DropDocument> findInBucket(Long bucketId, DropFilter dropFilter,
+			Pageable pageable);
 
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/solr/util/QueryUtil.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/solr/util/QueryUtil.java
@@ -31,17 +31,18 @@ public class QueryUtil {
 	/**
 	 * Given a comma-separated list of search terms; 
 	 * <code>searchTerms</code>, converts the list to an array
-	 * and concatenates the elements using "AND". The final
-	 * {@link String} is encapsulated in parantheses "()"
-	 * before being returned for use in a Solr search query
+	 * and concatenates the elements using "AND".
 	 * 
-	 *  If <code>searchTerm</code> comprises of only one string,
-	 *  no modification takes place
+	 * If <code>searchTerm</code> comprises of only one string,
+	 * no modification takes place
 	 * 
 	 * @param searchTerms
 	 * @return
 	 */
 	public static String getQueryString(String searchTerms) {
+		if (searchTerms == null || searchTerms.trim().length() == 0)
+			return "*:*";
+
 		List<String> keywordsList = new ArrayList<String>();
 
 		// Sanitize the each keyword
@@ -53,7 +54,7 @@ public class QueryUtil {
 		String[] keywordsArray = keywordsList.toArray(new String[keywordsList.size()]);
 
 		return keywordsArray.length == 1 
-				? searchTerms : "(" + StringUtils.join(keywordsArray, " AND ") + ")";
+				? searchTerms : StringUtils.join(keywordsArray, " AND ");
 		
 	}
 }

--- a/src/test/java/com/ushahidi/swiftriver/core/api/filter/DropFilterTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/api/filter/DropFilterTest.java
@@ -1,0 +1,55 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/agpl.html>
+ * 
+ * Copyright (C) Ushahidi Inc. All Rights Reserved.
+ */
+package com.ushahidi.swiftriver.core.api.filter;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.ushahidi.swiftriver.core.api.exception.InvalidFilterException;
+import com.ushahidi.swiftriver.core.api.filter.DropFilter.BoundingBox;
+
+/**
+ * Unit test for the {@link DropFilter} class
+ * 
+ * @author ekala
+ */
+public class DropFilterTest {
+
+	/**
+	 * Verifies that the <code>location</code> property of
+	 * the filter is valid 
+	 */
+	@Test
+	public void setValidLocation() {
+		DropFilter dropFilter = new DropFilter();
+		dropFilter.setBoundingBox("36.8,-122.75,37.8,-121.75");
+		
+		BoundingBox boundingBox = dropFilter.getBoundingBox();
+
+		assertEquals("36.8", boundingBox.getLatFrom().toString());
+		assertEquals("-122.75", boundingBox.getLonFrom().toString());
+		assertEquals("37.8", boundingBox.getLatTo().toString());
+		assertEquals("-121.75", boundingBox.getLonTo().toString());
+	}
+	
+	@Test(expected = InvalidFilterException.class)
+	public void setInvalidLocation() {
+		DropFilter dropFilter = new DropFilter();
+		dropFilter.setBoundingBox("-122.75,36.8,-121.75,37.8");
+	}
+}

--- a/src/test/java/com/ushahidi/swiftriver/core/api/filter/DropFilterTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/api/filter/DropFilterTest.java
@@ -42,14 +42,20 @@ public class DropFilterTest {
 		BoundingBox boundingBox = dropFilter.getBoundingBox();
 
 		assertEquals("36.8", boundingBox.getLatFrom().toString());
-		assertEquals("-122.75", boundingBox.getLonFrom().toString());
+		assertEquals("-122.75", boundingBox.getLngFrom().toString());
 		assertEquals("37.8", boundingBox.getLatTo().toString());
-		assertEquals("-121.75", boundingBox.getLonTo().toString());
+		assertEquals("-121.75", boundingBox.getLngTo().toString());
 	}
 	
 	@Test(expected = InvalidFilterException.class)
 	public void setInvalidLocation() {
 		DropFilter dropFilter = new DropFilter();
 		dropFilter.setBoundingBox("-122.75,36.8,-121.75,37.8");
+	}
+	
+	@Test(expected = InvalidFilterException.class)
+	public void setInvalidBoundingBox() {
+		DropFilter dropFilter = new DropFilter();
+		dropFilter.setBoundingBox("37.8,-121.75,36.8,-122.75");
 	}
 }

--- a/src/test/java/com/ushahidi/swiftriver/core/api/service/DropIndexServiceTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/api/service/DropIndexServiceTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.dozer.DozerBeanMapper;
 import org.dozer.Mapper;
@@ -33,6 +34,7 @@ import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 import com.ushahidi.swiftriver.core.api.dao.DropDao;
 import com.ushahidi.swiftriver.core.model.Drop;
@@ -54,26 +56,35 @@ public class DropIndexServiceTest {
 	private Mapper mapper = new DozerBeanMapper();
 	
 	private DropDao mockDropDao;
+
+	private NamedParameterJdbcTemplate mockNamedJdbcTempalate;
 	
 	@Before
 	public void setUp() {
 		mockRepository = mock(DropDocumentRepository.class);
 		mockDropDao = mock(DropDao.class);
+		mockNamedJdbcTempalate = mock(NamedParameterJdbcTemplate.class);
 
 		dropIndexService = new DropIndexService();
 		dropIndexService.setRepository(mockRepository);
 		dropIndexService.setMapper(mapper);
 		dropIndexService.setDropDao(mockDropDao);
+		dropIndexService.setNamedJdbcTemplate(mockNamedJdbcTempalate);
 	}
 	
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	public void addToIndex() {
 		Drop mockDrop = mock(Drop.class);
 		
+		List<Map<String, Object>> testResultList = new ArrayList<Map<String,Object>>();
+		when(mockNamedJdbcTempalate.queryForList(anyString(),
+				any(Map.class))).thenReturn(testResultList);
+
 		dropIndexService.addToIndex(mockDrop);
 
-		ArgumentCaptor<DropDocument> dropDocumentArgument = ArgumentCaptor.forClass(DropDocument.class);
-		verify(mockRepository).save(dropDocumentArgument .capture());
+		ArgumentCaptor<List> dropDocumentListArgument = ArgumentCaptor.forClass(List.class);
+		verify(mockRepository).save(dropDocumentListArgument.capture());
 	}
 	
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -82,7 +93,14 @@ public class DropIndexServiceTest {
 		List<Drop> drops = new ArrayList<Drop>();
 		drops.add(mock(Drop.class));
 		drops.add(mock(Drop.class));
+
+		List<Map<String, Object>> testResultList = new ArrayList<Map<String,Object>>();
+
+		when(mockNamedJdbcTempalate.queryForList(anyString(), 
+				any(Map.class))).thenReturn(testResultList);
+
 		dropIndexService.addAllToIndex(drops);
+
 		ArgumentCaptor<List> dropDocumentListArgument = ArgumentCaptor
 				.forClass(List.class);
 		verify(mockRepository).save(dropDocumentListArgument.capture());

--- a/src/test/java/com/ushahidi/swiftriver/core/solr/InitSolrSearchIndex.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/solr/InitSolrSearchIndex.java
@@ -18,9 +18,6 @@ package com.ushahidi.swiftriver.core.solr;
 
 import java.util.List;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
@@ -49,9 +46,6 @@ public class InitSolrSearchIndex {
 	@Autowired
 	private DropIndexService dropIndexService;
 
-	@PersistenceContext
-	private EntityManager entityManager;
-	
 	@Autowired
 	private DropDao dropDao;
 
@@ -60,12 +54,8 @@ public class InitSolrSearchIndex {
 		dropIndexService.deleteAllFromIndex();
 
 		// Fetch the drops and them to the index 
-		List<Drop> drops = entityManager.createQuery("FROM Drop", 
-				Drop.class).getResultList();
+		List<Drop> drops = dropDao.findAll(0, 1000);
 
-		dropDao.populateBucketIds(drops);
-		dropDao.populateRiverIds(drops);
-		
 		dropIndexService.addAllToIndex(drops);
 	}
 }

--- a/src/test/java/com/ushahidi/swiftriver/core/solr/repository/DropDocumentRepositoryImplTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/solr/repository/DropDocumentRepositoryImplTest.java
@@ -114,7 +114,7 @@ public class DropDocumentRepositoryImplTest {
 
 		Pageable pageRequest = new PageRequest(0, 20);
 		DropFilter dropFilter = new DropFilter();
-		dropFilter.setBoundingBox("40,-74,-73,41");
+		dropFilter.setBoundingBox("40,-74,41,-73");
 
 		dropSearchRepository.findInBucket(20L, dropFilter, pageRequest);
 		ArgumentCaptor<SolrQuery> solrQueryArgument = ArgumentCaptor.forClass(SolrQuery.class);
@@ -124,7 +124,7 @@ public class DropDocumentRepositoryImplTest {
 		
 		String[] expectedFilterQuery = new String[]{
 				"bucketId:(20)",
-				"geo:[40.0,-74.0 TO -73.0,41.0]"
+				"geo:[40.0,-74.0 TO 41.0,-73.0]"
 				};
 		
 		String[] actualFilterQuery = solrQuery.getFilterQueries();

--- a/src/test/java/com/ushahidi/swiftriver/core/solr/util/QueryUtilTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/solr/util/QueryUtilTest.java
@@ -1,0 +1,63 @@
+/**
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/agpl.html>
+ * 
+ * Copyright (C) Ushahidi Inc. All Rights Reserved.
+ */
+package com.ushahidi.swiftriver.core.solr.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/**
+ * Unit test for the {@link QueryUtil} class
+ * 
+ * @author ekala
+ */
+public class QueryUtilTest {
+
+	/**
+	 * Where a single query string has been specified
+	 */
+	@Test
+	public void singleQueryString() {
+		String queryString = QueryUtil.getQueryString("ushahidi");
+		
+		assertEquals("ushahidi", queryString);
+	}
+	
+	/**
+	 * Where no query string has been specified
+	 */
+	@Test
+	public void nullQueryString() {
+		String nullString = QueryUtil.getQueryString(null);
+		assertEquals("*:*", nullString);
+		
+		String emptyString = QueryUtil.getQueryString("");
+		assertEquals(emptyString, nullString);
+	}
+	
+	/**
+	 * Where multiple (comma separated) query strings
+	 * have been specified
+	 */
+	@Test
+	public void multipleQueryStrings() {
+		String queryString = QueryUtil.getQueryString("ushahidi,elections,kenya");
+		
+		String expected = "ushahidi AND elections AND kenya";
+		assertEquals(expected, queryString);
+	}
+}


### PR DESCRIPTION
This implements spatial queries by introducing the `locations` query parameter in `GET rivers/:id/drops` AND `buckets/:id/drops`

This parameter takes in a comma-separated list of latitude,longitude pairs; with the SouthWest corner of the bounding box coming first e.g.

```
1.3091474,36.78669,-1.2561173,36.851406
```

This closes #31 
