### PR TITLE
Single DTO for stripped down Account

### DIFF
--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/AccountDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/AccountDTO.java
@@ -19,23 +19,21 @@ package com.ushahidi.swiftriver.core.api.dto;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
- * DTO mapping class for getting drop comments
+ * DTO mapping class that is a stripped down version
+ * of <code>com.ushahidi.swiftriver.core.api.GetAccountDTO</code>
  * 
  * @author ekala
  *
  */
-public class GetCommentDTO {
+public class AccountDTO {
 	
 	private long id;
 	
-	@JsonProperty("comment_text")
-	private String commentText;
+	@JsonProperty("account_path")
+	private String accountPath;
 	
-	@JsonProperty("date_added")
-	private String dateAdded;
+	private Owner owner;
 	
-	private AccountDTO account;
-
 	public long getId() {
 		return id;
 	}
@@ -44,28 +42,43 @@ public class GetCommentDTO {
 		this.id = id;
 	}
 
-	public String getCommentText() {
-		return commentText;
+	public String getAccountPath() {
+		return accountPath;
 	}
 
-	public void setCommentText(String commentText) {
-		this.commentText = commentText;
+	public void setAccountPath(String accountPath) {
+		this.accountPath = accountPath;
 	}
 
-	public String getDateAdded() {
-		return dateAdded;
+	public Owner getOwner() {
+		return owner;
 	}
 
-	public void setDateAdded(String dateAdded) {
-		this.dateAdded = dateAdded;
+	public void setOwner(Owner owner) {
+		this.owner = owner;
 	}
 
-	public AccountDTO getAccount() {
-		return account;
+	public static class Owner {
+		
+		private String avatar;
+		
+		private String name;
+
+		public String getAvatar() {
+			return avatar;
+		}
+
+		public void setAvatar(String avatar) {
+			this.avatar = avatar;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
 	}
 
-	public void setAccount(AccountDTO account) {
-		this.account = account;
-	}
-	
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetActivityDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetActivityDTO.java
@@ -1,22 +1,26 @@
 /**
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/agpl.html>
+ * 
+ * Copyright (C) Ushahidi Inc. All Rights Reserved.
  */
 package com.ushahidi.swiftriver.core.api.dto;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
 /**
+ * DTO class for activities
+ * 
  * @author Ushahidi, Inc
  *
  */
@@ -27,7 +31,7 @@ public class GetActivityDTO {
 	@JsonProperty("date_added")
 	private String actionDateAdd;
 	
-	private Account account;
+	private AccountDTO account;
 	
 	private String action;
 	
@@ -37,7 +41,7 @@ public class GetActivityDTO {
 	@JsonProperty("action_on_obj")
 	private Object actionOnObj;
 	
-	private Account actionTo;
+	private AccountDTO actionTo;
 
 	public String getId() {
 		return id;
@@ -55,11 +59,11 @@ public class GetActivityDTO {
 		this.actionDateAdd = actionDateAdd;
 	}
 
-	public Account getAccount() {
+	public AccountDTO getAccount() {
 		return account;
 	}
 
-	public void setAccount(Account account) {
+	public void setAccount(AccountDTO account) {
 		this.account = account;
 	}
 
@@ -87,68 +91,11 @@ public class GetActivityDTO {
 		this.actionOnObj = actionOnObj;
 	}
 
-	public Account getActionTo() {
+	public AccountDTO getActionTo() {
 		return actionTo;
 	}
 
-	public void setActionTo(Account actionTo) {
+	public void setActionTo(AccountDTO actionTo) {
 		this.actionTo = actionTo;
-	}
-	
-	public static class Account {
-		
-		private long id;
-		
-		@JsonProperty("account_path")
-		private String accountPath;
-		
-		private Owner owner;
-		
-		public long getId() {
-			return id;
-		}
-
-		public void setId(long id) {
-			this.id = id;
-		}
-
-		public String getAccountPath() {
-			return accountPath;
-		}
-
-		public void setAccountPath(String accountPath) {
-			this.accountPath = accountPath;
-		}
-
-		public Owner getOwner() {
-			return owner;
-		}
-
-		public void setOwner(Owner owner) {
-			this.owner = owner;
-		}
-
-		public static class Owner {
-			
-			private String avatar;
-			
-			private String name;
-
-			public String getAvatar() {
-				return avatar;
-			}
-
-			public void setAvatar(String avatar) {
-				this.avatar = avatar;
-			}
-
-			public String getName() {
-				return name;
-			}
-
-			public void setName(String name) {
-				this.name = name;
-			}
-		}
 	}
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetBucketCollaboratorDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetBucketCollaboratorDTO.java
@@ -1,16 +1,18 @@
 /**
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/agpl.html>
+ * 
+ * Copyright (C) Ushahidi Inc. All Rights Reserved.
  */
 package com.ushahidi.swiftriver.core.api.dto;
 
@@ -21,6 +23,8 @@ package com.ushahidi.swiftriver.core.api.dto;
 public class GetBucketCollaboratorDTO extends GetCollaboratorDTO {
 
 	private GetBucketDTO bucket;
+	
+	private AccountDTO account;
 
 	public GetBucketDTO getBucket() {
 		return bucket;
@@ -28,6 +32,14 @@ public class GetBucketCollaboratorDTO extends GetCollaboratorDTO {
 
 	public void setBucket(GetBucketDTO bucket) {
 		this.bucket = bucket;
+	}
+
+	public AccountDTO getAccount() {
+		return account;
+	}
+
+	public void setAccount(AccountDTO account) {
+		this.account = account;
 	}
 	
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetBucketDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetBucketDTO.java
@@ -51,32 +51,8 @@ public class GetBucketDTO {
 	@JsonProperty("public")
 	private boolean published;
 
-	private Account account;
+	private AccountDTO account;
 	
-	public static class Account {
-		private long id;
-		
-		@JsonProperty("account_path")
-		private String accountPath;
-
-		public long getId() {
-			return id;
-		}
-
-		public void setId(long id) {
-			this.id = id;
-		}
-
-		public String getAccountPath() {
-			return accountPath;
-		}
-
-		public void setAccountPath(String accountPath) {
-			this.accountPath = accountPath;
-		}
-		
-	}
-
 	public long getId() {
 		return id;
 	}
@@ -157,11 +133,11 @@ public class GetBucketDTO {
 		this.published = published;
 	}
 
-	public Account getAccount() {
+	public AccountDTO getAccount() {
 		return account;
 	}
 
-	public void setAccount(Account account) {
+	public void setAccount(AccountDTO account) {
 		this.account = account;
 	}
 

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetCollaboratorDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetCollaboratorDTO.java
@@ -20,9 +20,16 @@ import java.util.Date;
 
 import org.codehaus.jackson.annotate.JsonProperty;
 
+import com.ushahidi.swiftriver.core.api.dto.AccountDTO.Owner;
+
 public class GetCollaboratorDTO {
 	
 	private long id;
+	
+	@JsonProperty("account_path")
+	private String accountPath;
+	
+	private Owner owner;
 	
 	private boolean active;
 	
@@ -32,14 +39,29 @@ public class GetCollaboratorDTO {
 	@JsonProperty("date_added")
 	private Date dateAdded;
 	
-	private Account account;
-
 	public long getId() {
 		return id;
 	}
 
 	public void setId(long id) {
 		this.id = id;
+	}
+
+	public String getAccountPath() {
+		return accountPath;
+	}
+
+
+	public void setAccountPath(String accountPath) {
+		this.accountPath = accountPath;
+	}
+
+	public Owner getOwner() {
+		return owner;
+	}
+
+	public void setOwner(Owner owner) {
+		this.owner = owner;
 	}
 
 	public boolean isActive() {
@@ -64,71 +86,5 @@ public class GetCollaboratorDTO {
 
 	public void setDateAdded(Date dateAdded) {
 		this.dateAdded = dateAdded;
-	}
-
-	public Account getAccount() {
-		return account;
-	}
-
-	public void setAccount(Account account) {
-		this.account = account;
-	}
-
-	public static class Account {
-		
-		private long id;
-		
-		@JsonProperty("account_path")
-		private String accountPath;
-		
-		private Owner owner;
-		
-		public long getId() {
-			return id;
-		}
-
-		public void setId(long id) {
-			this.id = id;
-		}
-
-		public String getAccountPath() {
-			return accountPath;
-		}
-
-		public void setAccountPath(String accountPath) {
-			this.accountPath = accountPath;
-		}
-
-		public Owner getOwner() {
-			return owner;
-		}
-
-		public void setOwner(Owner owner) {
-			this.owner = owner;
-		}
-
-		public static class Owner {
-			
-			private String name;
-			
-			private String avatar;
-
-			public String getName() {
-				return name;
-			}
-
-			public void setName(String name) {
-				this.name = name;
-			}
-
-			public String getAvatar() {
-				return avatar;
-			}
-
-			public void setAvatar(String avatar) {
-				this.avatar = avatar;
-			}
-		}
-
 	}
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetRiverCollaboratorDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetRiverCollaboratorDTO.java
@@ -1,16 +1,18 @@
 /**
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU Affero General Public License as
- *  published by the Free Software Foundation, either version 3 of the
- *  License, or (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU Affero General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
  *
- *  You should have received a copy of the GNU Affero General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/agpl.html>
+ * 
+ * Copyright (C) Ushahidi Inc. All Rights Reserved.
  */
 package com.ushahidi.swiftriver.core.api.dto;
 
@@ -21,6 +23,8 @@ package com.ushahidi.swiftriver.core.api.dto;
 public class GetRiverCollaboratorDTO extends GetCollaboratorDTO {
 	
 	private GetRiverDTO river;
+	
+	private AccountDTO account;
 
 	public GetRiverDTO getRiver() {
 		return river;
@@ -29,4 +33,13 @@ public class GetRiverCollaboratorDTO extends GetCollaboratorDTO {
 	public void setRiver(GetRiverDTO river) {
 		this.river = river;
 	}
+
+	public AccountDTO getAccount() {
+		return account;
+	}
+
+	public void setAccount(AccountDTO account) {
+		this.account = account;
+	}
+	
 }

--- a/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetRiverDTO.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/dto/GetRiverDTO.java
@@ -33,7 +33,7 @@ public class GetRiverDTO {
 	
 	private String category;
 	
-	private Account account;
+	private AccountDTO account;
 	
 	@JsonProperty("follower_count")
 	private int followerCount;
@@ -64,30 +64,6 @@ public class GetRiverDTO {
 	private long maxDropId;
 	
 	private List<Channel> channels;
-	
-	public static class Account {
-		
-		private long id;
-		
-		@JsonProperty("account_path")
-		private String accountPath;
-
-		public long getId() {
-			return id;
-		}
-
-		public void setId(long id) {
-			this.id = id;
-		}
-
-		public String getAccountPath() {
-			return accountPath;
-		}
-
-		public void setAccountPath(String accountPath) {
-			this.accountPath = accountPath;
-		}
-	}
 	
 	public static class Channel {
 		
@@ -176,11 +152,11 @@ public class GetRiverDTO {
 		this.category = category;
 	}
 
-	public Account getAccount() {
+	public AccountDTO getAccount() {
 		return account;
 	}
 
-	public void setAccount(Account account) {
+	public void setAccount(AccountDTO account) {
 		this.account = account;
 	}
 

--- a/src/main/java/com/ushahidi/swiftriver/core/api/service/AccountService.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/service/AccountService.java
@@ -956,11 +956,8 @@ public class AccountService {
 	
 			// Update last id
 			if (lastId != null) {
-				if (newer != null && newer) {
-					lastId = Math.max(lastId, activity.getId());
-				} else {
-					lastId = Math.min(lastId, activity.getId());
-				}
+				lastId = (newer != null && newer) 
+						? Math.max(lastId, activity.getId()) : Math.min(lastId, activity.getId());
 			} else {
 				lastId = activity.getId();
 			}

--- a/src/main/java/com/ushahidi/swiftriver/core/api/service/BucketService.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/service/BucketService.java
@@ -374,8 +374,7 @@ public class BucketService {
 		List<GetCollaboratorDTO> collaborators = new ArrayList<GetCollaboratorDTO>();
 
 		for (BucketCollaborator collaborator : bucket.getCollaborators()) {
-			collaborators.add(mapper
-					.map(collaborator, GetCollaboratorDTO.class));
+			collaborators.add(mapCollaboratorDTO(collaborator));
 		}
 
 		return collaborators;
@@ -417,7 +416,7 @@ public class BucketService {
 		
 		accountService.logActivity(authAccount, ActivityType.INVITE, collaborator);
 
-		return mapper.map(collaborator, GetCollaboratorDTO.class);
+		return mapCollaboratorDTO(collaborator);
 	}
 
 	/**
@@ -462,7 +461,7 @@ public class BucketService {
 		// Post changes to the DB
 		bucketDao.updateCollaborator(collaborator);
 
-		return mapper.map(collaborator, GetCollaboratorDTO.class);
+		return mapCollaboratorDTO(collaborator);
 	}
 
 	/**
@@ -500,6 +499,22 @@ public class BucketService {
 		}
 
 		bucketCollaboratorDao.delete(collaborator);
+	}
+
+	/**
+	 * Utility method for mapping a {@link BucketCollaborator} object
+	 * to its DTO - {@link GetCollaboratorDTO}
+	 *  
+	 * @param collaborator
+	 * @return
+	 */
+	private GetCollaboratorDTO mapCollaboratorDTO(BucketCollaborator collaborator) {
+		GetCollaboratorDTO collaboratorDTO = mapper.map(
+				collaborator.getAccount(), GetCollaboratorDTO.class);
+		
+		collaboratorDTO.setActive(collaborator.isActive());
+		collaboratorDTO.setReadOnly(collaborator.isReadOnly());
+		return collaboratorDTO;
 	}
 
 	/**

--- a/src/main/java/com/ushahidi/swiftriver/core/api/service/RiverService.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/service/RiverService.java
@@ -504,8 +504,7 @@ public class RiverService {
 		List<GetCollaboratorDTO> collaborators = new ArrayList<GetCollaboratorDTO>();
 
 		for (RiverCollaborator collaborator : river.getCollaborators()) {
-			collaborators.add(mapper
-					.map(collaborator, GetCollaboratorDTO.class));
+			collaborators.add(mapCollaboratorDTO(collaborator));
 		}
 
 		return collaborators;
@@ -547,7 +546,7 @@ public class RiverService {
 		
 		accountService.logActivity(authAccount, ActivityType.INVITE, collaborator);
 
-		return mapper.map(collaborator, GetCollaboratorDTO.class);
+		return mapCollaboratorDTO(collaborator);
 	}
 
 	/**
@@ -589,7 +588,7 @@ public class RiverService {
 		// Post changes to the DB
 		riverDao.updateCollaborator(collaborator);
 
-		return mapper.map(collaborator, GetCollaboratorDTO.class);
+		return mapCollaboratorDTO(collaborator);
 	}
 
 	/**
@@ -621,6 +620,15 @@ public class RiverService {
 		}
 
 		riverCollaboratorDao.delete(collaborator);
+	}
+
+	private GetCollaboratorDTO mapCollaboratorDTO(RiverCollaborator collaborator) {
+		GetCollaboratorDTO collaboratorDTO = mapper.map(
+				collaborator.getAccount(), GetCollaboratorDTO.class);
+		collaboratorDTO.setActive(collaborator.isActive());
+		collaboratorDTO.setReadOnly(collaborator.isReadOnly());
+	
+		return collaboratorDTO;
 	}
 
 	/**

--- a/src/test/java/com/ushahidi/swiftriver/core/api/controller/BucketsControllerTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/api/controller/BucketsControllerTest.java
@@ -289,14 +289,12 @@ public class BucketsControllerTest extends AbstractControllerTest {
 				.andExpect(
 						content().contentType("application/json;charset=UTF-8"))
 				.andExpect(jsonPath("$").value(hasSize(2)))
-				.andExpect(jsonPath("$[1].id").value(2))
+				.andExpect(jsonPath("$[1].id").value(4))
 				.andExpect(jsonPath("$[1].active").value(true))
 				.andExpect(jsonPath("$[1].read_only").value(true))
-				.andExpect(jsonPath("$[1].account.id").value(4))
-				.andExpect(jsonPath("$[1].account.account_path").value("user2"))
-				.andExpect(jsonPath("$[1].account.owner.name").value("User 2"))
-				.andExpect(
-						jsonPath("$[1].account.owner.avatar")
+				.andExpect(jsonPath("$[1].account_path").value("user2"))
+				.andExpect(jsonPath("$[1].owner.name").value("User 2"))
+				.andExpect(jsonPath("$[1].owner.avatar")
 								.value("https://secure.gravatar.com/avatar/ee8ce7cae1c9d064b9a2c049ce4a1071?s=80&d=mm&r=g"));
 	}
 

--- a/src/test/java/com/ushahidi/swiftriver/core/api/controller/RiversControllerTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/api/controller/RiversControllerTest.java
@@ -286,14 +286,12 @@ public class RiversControllerTest extends AbstractControllerTest {
 				.andExpect(
 						content().contentType("application/json;charset=UTF-8"))
 				.andExpect(jsonPath("$").value(hasSize(2)))
-				.andExpect(jsonPath("$[1].id").value(2))
+				.andExpect(jsonPath("$[1].id").value(5))
 				.andExpect(jsonPath("$[1].active").value(true))
 				.andExpect(jsonPath("$[1].read_only").value(true))
-				.andExpect(jsonPath("$[1].account.id").value(5))
-				.andExpect(jsonPath("$[1].account.account_path").value("user3"))
-				.andExpect(jsonPath("$[1].account.owner.name").value("User 3"))
-				.andExpect(
-						jsonPath("$[1].account.owner.avatar")
+				.andExpect(jsonPath("$[1].account_path").value("user3"))
+				.andExpect(jsonPath("$[1].owner.name").value("User 3"))
+				.andExpect(jsonPath("$[1].owner.avatar")
 								.value("https://secure.gravatar.com/avatar/a9902dcbf6185ac32079d358dcbdf148?s=80&d=mm&r=g"));
 	}
 


### PR DESCRIPTION
- Replaced all the static inner Account classes in the DTO objects to
  the AccountDTO class. This makes the DTO classes that return an
  account object much cleaner, reduces redundancy and espouses
  reuse
- Refactored GetCollaboratorDTO so that only the account and owner
  information is returned. This is following the change that switches
  the `(rivers/buckets)/:id/collaborators` to use the :account_id instead
  of :collaborator_id
- Refs #45
