### PR TITLE
Update river drop count on delete river channel

### DIFF
--- a/src/main/java/com/ushahidi/swiftriver/core/api/service/RiverService.java
+++ b/src/main/java/com/ushahidi/swiftriver/core/api/service/RiverService.java
@@ -328,7 +328,18 @@ public class RiverService {
 	@Transactional(readOnly = false)
 	public void deleteChannel(Long riverId, Long channelId, String authUser) {
 		Channel channel = getRiverChannel(riverId, channelId, authUser);
+
+		int channelDropCount = channel.getDropCount();
+		River river = channel.getRiver();
+
 		channelDao.delete(channel);
+		
+		// Update the river drop count
+		logger.debug("Reducing the drop count of river {} by {} drops",
+				riverId, channelDropCount);
+
+		river.setDropCount(river.getDropCount() - channelDropCount);
+		riverDao.update(river);
 
 		// Construct the routing key
 		String routingKey = String.format("web.channel.%s.delete", 

--- a/src/test/java/com/ushahidi/swiftriver/core/api/service/RiverServiceTest.java
+++ b/src/test/java/com/ushahidi/swiftriver/core/api/service/RiverServiceTest.java
@@ -307,9 +307,11 @@ public class RiverServiceTest {
 		River river = new River();
 		river.setId(1L);
 		river.setAccount(account);
+		river.setDropCount(800);
 		Channel channel = new Channel();
 		channel.setChannel("the channel");
 		channel.setParameters("the parameters");
+		channel.setDropCount(300);
 		channel.setRiver(river);
 
 		when(mockAccountDao.findByUsernameOrEmail(anyString())).thenReturn(account);
@@ -324,7 +326,7 @@ public class RiverServiceTest {
 		verify(mockAmqpTemplate).convertAndSend(routingKeyArgument.capture(),
 				notificationArgument.capture());
 		ChannelUpdateNotification notification = notificationArgument
-				.getValue();
+				.getValue();		
 		assertEquals("the channel", notification.getChannel());
 		assertEquals("the parameters", notification.getParameters());
 		assertEquals(1L, notification.getRiverId());
@@ -332,6 +334,8 @@ public class RiverServiceTest {
 				routingKeyArgument.getValue());
 
 		verify(mockChannelDao).delete(channel);
+		verify(mockRiverDao).update(river);
+		assertEquals(500, river.getDropCount().intValue());
 	}
 
 	@Test


### PR DESCRIPTION
- When a river channel is deleted, reduce the drop count of
  the river by the drop count of the channel. Closes #50
