### PR TITLE
Fixing column type to avoid java cast error

### DIFF
--- a/src/main/resources/config/sql/schema.sql
+++ b/src/main/resources/config/sql/schema.sql
@@ -26,7 +26,7 @@ CREATE TABLE IF NOT EXISTS tags (
   PRIMARY KEY (id),
   UNIQUE  (hash)
 );
-CREATE INDEX tags_idx_tag_canonical ON tags (tag_canonical);  
+CREATE INDEX tags_idx_tag_canonical ON tags (tag_canonical);
 
 
 -- -----------------------------------------------------
@@ -38,8 +38,8 @@ CREATE TABLE IF NOT EXISTS droplets_links (
   link_id bigint NOT NULL,
   UNIQUE (droplet_id,link_id)
 );
-CREATE INDEX droplets_links_idx_link_id ON droplets_links (link_id);  
-CREATE INDEX droplets_links_idx_droplet_id ON droplets_links (droplet_id);  
+CREATE INDEX droplets_links_idx_link_id ON droplets_links (link_id);
+CREATE INDEX droplets_links_idx_droplet_id ON droplets_links (droplet_id);
 
 
 -- -----------------------------------------------------
@@ -233,7 +233,7 @@ CREATE TABLE IF NOT EXISTS roles (
 -- Table identities
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS identities (
-  id bigint NOT NULL,
+  id bigint UNSIGNED NOT NULL,
   hash char(32) NOT NULL,
   channel varchar(20) NOT NULL,
   identity_orig_id LONGTEXT DEFAULT NULL,
@@ -498,7 +498,7 @@ CREATE TABLE IF NOT EXISTS bucket_collaborators (
   bucket_id bigint NOT NULL,
   collaborator_active boolean default false,
   read_only boolean default true,
-  date_added TIMESTAMP,  
+  date_added TIMESTAMP,
   UNIQUE (account_id,bucket_id)
 );
 


### PR DESCRIPTION
Current database throws:

```
ERROR com.ushahidi.swiftriver.core.api.controller.AbstractController - java.lang.ClassCastException: java.lang.Long cannot be cast to java.math.BigInteger
        at com.ushahidi.swiftriver.core.api.dao.impl.JpaIdentityDao.updateNewIdentityIndex(JpaIdentityDao.java:133)
```

This fixes things! :)
